### PR TITLE
Add input loading to BusinessStrategyAgent

### DIFF
--- a/AiFoundryExp.Tests/BusinessStrategyAgentTests.cs
+++ b/AiFoundryExp.Tests/BusinessStrategyAgentTests.cs
@@ -1,5 +1,6 @@
 using AiFoundryExp;
 using AiFoundryExp.Agents;
+using Azure.AI.Agents.Persistent;
 
 namespace AiFoundryExp.Tests;
 
@@ -7,6 +8,21 @@ public class BusinessStrategyAgentTests
 {
     private static BusinessStrategyAgent CreateAgent(IMessageBus bus)
         => new(new AgentDefinition { Name = "Business Strategy Agent" }, bus);
+
+    private class TestBus : IMessageBus
+    {
+        public string? PromptedText;
+        public string Prompt(string recipient, string prompt)
+        {
+            PromptedText = prompt;
+            return "none";
+        }
+
+        public void Publish(AgentMessage message) { }
+        public void Subscribe(string recipient, Action<AgentMessage> handler) { }
+        public void Unsubscribe(string recipient, Action<AgentMessage> handler) { }
+        public void RegisterRemoteAgent(string name, PersistentAgentsClient client, PersistentAgent agent) { }
+    }
 
     [Fact]
     public void BuildBusinessModel_MapsContextValues()
@@ -45,5 +61,29 @@ public class BusinessStrategyAgentTests
         Assert.All(received, m => Assert.Equal("User Interaction Agent", m.Recipient));
         Assert.Contains(received, m => m.Content.Contains("target market", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(received, m => m.Content.Contains("revenue model", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void GenerateNextQuestion_LoadsInputFile()
+    {
+        TestBus bus = new();
+        BusinessStrategyAgent agent = CreateAgent(bus);
+        var context = new Dictionary<string, string>();
+
+        string dir = Path.Combine(AppContext.BaseDirectory, "input");
+        Directory.CreateDirectory(dir);
+        string file = Path.Combine(dir, "input.txt");
+        File.WriteAllText(file, "target_market: testers");
+        try
+        {
+            agent.GenerateNextQuestion(context);
+            Assert.Equal("testers", context["target_market"]);
+        }
+        finally
+        {
+            File.Delete(file);
+            if (Directory.Exists(dir) && Directory.GetFileSystemEntries(dir).Length == 0)
+                Directory.Delete(dir);
+        }
     }
 }

--- a/AiFoundryExp.Tests/OrchestrationAgentTests.cs
+++ b/AiFoundryExp.Tests/OrchestrationAgentTests.cs
@@ -23,6 +23,9 @@ public class OrchestrationAgentTests
 
         public void RegisterRemoteAgent(string name, PersistentAgentsClient client, PersistentAgent agent)
             => _inner.RegisterRemoteAgent(name, client, agent);
+
+        public string Prompt(string recipient, string prompt)
+            => _inner.Prompt(recipient, prompt);
     }
 
     private static OrchestrationAgent CreateAgent() =>

--- a/AiFoundryExp/Agents/BusinessStrategyAgent.cs
+++ b/AiFoundryExp/Agents/BusinessStrategyAgent.cs
@@ -1,3 +1,5 @@
+using AiFoundryExp;
+
 namespace AiFoundryExp.Agents;
 
 /// <summary>
@@ -6,6 +8,8 @@ namespace AiFoundryExp.Agents;
 public class BusinessStrategyAgent : BaseAgent
 {
     public BusinessStrategyAgent(AgentDefinition definition, IMessageBus bus) : base(definition, bus) { }
+
+    private bool _inputLoaded;
 
     private readonly string[] _fields = ["business_idea", "target_market", "revenue_model"]; 
 
@@ -47,6 +51,20 @@ public class BusinessStrategyAgent : BaseAgent
 
     public override string? GenerateNextQuestion(Dictionary<string, string> context)
     {
+        if (!_inputLoaded)
+        {
+            string path = Path.Combine(AppContext.BaseDirectory, "input", "input.txt");
+            Dictionary<string, string> fileContext = InputParser.ParseFile(path);
+            foreach (var kv in fileContext)
+            {
+                if (!context.ContainsKey(kv.Key))
+                {
+                    context[kv.Key] = kv.Value;
+                }
+            }
+            _inputLoaded = true;
+        }
+
         return base.GenerateNextQuestion(context);
     }
 


### PR DESCRIPTION
## Summary
- load context from `input/input.txt` when BusinessStrategyAgent starts questioning
- update orchestration test bus implementation
- add unit test covering new input behaviour

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684c09d60efc832cabaf78a85a39dd82